### PR TITLE
Add docker compose file with release images

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,39 @@
+version: "3.9"
+services:
+  registry:
+    image:  gcr.io/linen-analyst-344721/speakeasy-api/registry:release-1.0.0
+    environment:
+      - SPEAKEASY_ENVIRONMENT=docker
+      - POSTGRES_DSN=postgres://postgres:postgres@postgres:5432/registry?sslmode=disable
+      - JWT_SECRET_KEY=sometestsecretkey
+    volumes:
+      - ~/.config/:/root/.config
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+    depends_on:
+      - postgres
+    networks:
+      - localnet
+  web:
+    image: gcr.io/linen-analyst-344721/speakeasy-api/web:release-1.0.0
+    networks:
+      - localnet
+    volumes:
+      - ~/.config/:/root/.config
+    ports:
+      - "3000:3000"
+  postgres:
+    image: postgres:alpine
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: registry
+    ports:
+      - "5432:5432"
+    networks:
+      - localnet
+networks:
+  localnet:
+    name: speakeasy_network


### PR DESCRIPTION
Give users option to run speakeasy using with docker compose. Instructions will be added here : https://docs.speakeasyapi.dev/technical-reference/self-host-speakeasy/running-locally-coming-soon