### PR TITLE
Add command for adding a new user to DB. Simplify docker-compose. Upgrade to image tag 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This repository contains the official **Helm 3** charts for installing and confi
 
 ## Running Locally
 
-The `docker-compose.yaml` and scripts folder contains everything needed to try out a local installation of speakeasy.
+The `docker-compose.yaml` and scripts folder contains everything needed to try out speakeasy.
 
-Please start at our [running locally documentation](https://docs.speakeasyapi.dev/technical-reference/self-host-speakeasy/running-locally)
+Please start at our [local-execution documentation](https://docs.speakeasyapi.dev/technical-reference/self-host-speakeasy/running-locally)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Speakeasy charts
 
-This repository contains the official **Helm 3** charts for installing and configuring Speakeasy. Please start at our [self-hosting documentation](https://docs.speakeasyapi.dev/speakeasy-user-guide/self-host-speakeasy-coming-soon) when deploying Speakeasy into your own cloud. 
+This repository contains the official **Helm 3** charts for installing and configuring Speakeasy. Please start at our [self-hosting documentation](https://docs.speakeasyapi.dev/technical-reference/self-host-speakeasy) when deploying Speakeasy into your own cloud.
+
+## Running Locally
+
+The `docker-compose.yaml` and scripts folder contains everything needed to try out a local installation of speakeasy.
+
+Please start at our [running locally documentation](https://docs.speakeasyapi.dev/technical-reference/self-host-speakeasy/running-locally)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,28 +1,24 @@
 version: "3.9"
 services:
   registry:
-    image:  gcr.io/linen-analyst-344721/speakeasy-api/registry:release-1.0.0
+    image: gcr.io/linen-analyst-344721/speakeasy-api/registry:release-1.1.0
     environment:
       - SPEAKEASY_ENVIRONMENT=docker
       - POSTGRES_DSN=postgres://postgres:postgres@postgres:5432/registry?sslmode=disable
-      - JWT_SECRET_KEY=1234567890123456789012345678901234567890123456789012345678901234
-      - GITHUB_CLIENT_ID=06c3bdd366b91fcf92cb
-      - GITHUB_CLIENT_SECRET=REPLACE_THIS_VALUE
-      - GITHUB_CALLBACK_URL=http://localhost:8080/v1/auth/callback/github
-      - SIGN_IN_URL=http://localhost:3000
     volumes:
       - ~/.config/:/root/.config
     ports:
       - "8080:8080"
       - "9090:9090"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     networks:
-      - localnet
+      - speakeasy_charts_network
   web:
-    image: gcr.io/linen-analyst-344721/speakeasy-api/web:release-1.0.0
+    image: gcr.io/linen-analyst-344721/speakeasy-api/web:release-1.1.0
     networks:
-      - localnet
+      - speakeasy_charts_network
     volumes:
       - ~/.config/:/root/.config
     ports:
@@ -36,8 +32,13 @@ services:
       POSTGRES_DB: registry
     ports:
       - "5432:5432"
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     networks:
-      - localnet
+      - speakeasy_charts_network
 networks:
-  localnet:
-    name: speakeasy_network
+  speakeasy_charts_network:
+    name: speakeasy_charts_network

--- a/scripts/add-user.bash
+++ b/scripts/add-user.bash
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+if ! command -v psql &> /dev/null
+then
+    printf "psql could not be found\n\n"
+    printf "  execute the following command to install psql:\n"
+    printf "  -----------------------\n"
+    printf "  brew install libpq\n"
+    exit 1
+fi
+
+read -p "Please state user email: " email
+echo "  => USER_EMAIL=\"${email}\""
+read -p "Should user email be an admin? [y/N]: " is_admin
+
+function set_add_normal_user_command() {
+	command_to_execute=$(cat <<-EOM
+    INSERT INTO users (id, email, display_name, created_at, updated_at, whitelisted, confirmed, admin)
+    VALUES (gen_random_uuid(),'$email', '$email',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,TRUE,TRUE,FALSE)
+    ON CONFLICT (email)
+    DO UPDATE SET
+    confirmed = true,
+    whitelisted = true,
+    admin = false,
+    updated_at = CURRENT_TIMESTAMP;
+	EOM
+	)
+}
+function set_add_admin_command() {
+	command_to_execute=$(cat <<-EOM
+    INSERT INTO users (id, email, display_name, created_at, updated_at, whitelisted, confirmed, admin)
+    VALUES (gen_random_uuid(),'$email', '$email',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,TRUE,TRUE,TRUE)
+    ON CONFLICT (email)
+    DO UPDATE SET
+    confirmed = true,
+    whitelisted = true,
+    admin = true,
+    updated_at = CURRENT_TIMESTAMP;
+	EOM
+	)
+}
+
+case "$is_admin" in
+	y|Y ) set_add_admin_command ;;
+	* ) set_add_normal_user_command ;;
+esac
+echo "  => COMMAND=\"${command_to_execute}\""
+
+PSQL_TARGET="postgresql://postgres:postgres@127.0.0.1:5432?sslmode=disable&dbname=registry"
+echo "  => PSQL_TARGET=\"${PSQL_TARGET}\""
+
+read -p "Confirm? [y/N]: " choice
+case "$choice" in
+	y|Y) echo "  => CONFIRMED=true";;
+	* ) exit 1;;
+esac
+
+echo "$ psql \"$PSQL_TARGET\" -c \"$command_to_execute\""
+psql "$PSQL_TARGET" -c "$command_to_execute"
+
+exit 0


### PR DESCRIPTION
 * Improves first-run experience by waiting for postgres DB to be connectable before booting registry image.
 * Adds a script that adds a new user to the local DB
 * Upgrades image tag to 1.1.0
 * Drops un-required environment variables from docker-compose.
 * Requires docker-compose `networks` name to not conflict with internal docker-compose
 
Following this PR, it should be possible to clone this repo, execute `docker-compose up`; execute ./scripts/add-user.bash (and enter github username when prompted); interact with the local speakeasy instance on localhost:3000. If a user locally adds themselves as an admin, they will observe the `speakeasy-self` internal workspace.