### PR TITLE
add grpc cert

### DIFF
--- a/charts/speakeasy-k8s/Chart.yaml
+++ b/charts/speakeasy-k8s/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "2.0.1"
+version: "2.0.2"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/speakeasy-k8s/README.md
+++ b/charts/speakeasy-k8s/README.md
@@ -38,7 +38,7 @@ Provide an overlay for the changes needed to `values.yaml` by following the sect
 Speakeasy uses Github OAuth to provide authentication for your org. Under settings for the Github Organization you'd like to
 authenticate, click "Developer Settings" > "Oauth Apps" > "New Oauth App". Fill in the fields (example in screenshot below). Please
 ensure the "Authorization callback URL" has a value in the form of `https://<DOMAIN>/v1/auth/callback/github`, where `<DOMAIN>`
-is replaced by the domain name of the A record (added in the [Ingress Section](#with-ingress) below).
+is replaced by the domain name of the web A record (added in the [Ingress Section](#with-ingress) below).
 
 ![](<../../assets/Screen Shot 2022-09-22 at 1.11.33 AM.png>)
 
@@ -200,7 +200,7 @@ Execute the following steps:
    ```
    kubectl get svc -n <NAMESPACE> emissary-ingress -o "go-template={{range .status.loadBalancer.ingress}}{{or .ip .hostname}}{{end}}"
    ```
-   Then, create an A record on your DNS to point your desired domain for Speakeasy to this IP. For example domain names, refer to
+   Then, create A records on your DNS to point your desired domains for Speakeasy's web and gRPC services to this IP. For example domain names, refer to
    the sample overlay in the end of the [Configuration](#configuration) section above.
 4. Install `cert-manager` with the following overlay:
     ```
@@ -225,22 +225,23 @@ Execute the following steps:
    ```
    kubectl apply -f <path/to/ambassador/cert-manager-ambassador-crds.yaml> --namespace=<NAMESPACE>
    ```
-6. Now, we have to provision the certificate for our Speakeasy domain.
+6. Now, we have to provision a certificate for each of our Speakeasy domains.
 
-   In `ambassador/ambassador-web-cert.yaml`, ensure the "$" wrapped value in `spec.dnsNames` is replaced with the corresponding
+   In `ambassador/ambassador-web-cert.yaml` and `ambassador/ambassador-grpc-cert.yaml`, ensure the "$" wrapped value in `spec.dnsNames` is replaced with the corresponding
    domain name for the A record you issued above.
    
-   Then deploy the certificate:
+   Then deploy each certificate:
    ```
    kubectl apply -f speakeasy-k8s/ambassador/ambassador-web-cert.yaml --namespace <NAMESPACE>
+   kubectl apply -f speakeasy-k8s/ambassador/ambassador-grpc-cert.yaml --namespace <NAMESPACE>
    ```
-   You may monitor the status of the certificate by issuing the following command
+   You may monitor the status of each certificate by issuing the following command
    and watching the "READY" column:
    ```
    kubectl get certificates -n <NAMESPACE> --watch
    ```
-7. The certificate from the previous step should now be ready. In `./ambassador/ambassador-mappings-and-hosts.yaml`, replace
-   all the "$" wrapped values for `spec.hostname`, and ensure they're equivalent to the domain name for the A record you 
+7. The certificates from the previous step should now be ready. In `./ambassador/ambassador-mappings-and-hosts.yaml`, replace
+   all the "$" wrapped values for `spec.hostname`, and ensure they're equivalent to the domain names for the A record you 
    issued above.<br/><br/>
    Then, apply the file:
    ```

--- a/charts/speakeasy-k8s/ambassador/ambassador-grpc-cert.yaml
+++ b/charts/speakeasy-k8s/ambassador/ambassador-grpc-cert.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ambassador-grpc-cert
+spec:
+  secretName: ambassador-grpc-cert
+  issuerRef:
+    name: speakeasy-letsencrypt
+    kind: ClusterIssuer
+  dnsNames:
+    - $YOUR_GRPC_HOSTNAME$ 

--- a/charts/speakeasy-k8s/ambassador/ambassador-mappings-and-hosts.yaml
+++ b/charts/speakeasy-k8s/ambassador/ambassador-mappings-and-hosts.yaml
@@ -4,9 +4,21 @@ kind: Host
 metadata:
   name: speakeasy-web
 spec:
-  hostname: $YOUR_WEB_HOSTNAME$
+  hostname: $YOUR_WEB_HOSTNAME$ 
   tlsSecret:
     name: ambassador-web-cert
+  requestPolicy:
+    insecure:
+      action: Redirect
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: speakeasy-grpc
+spec:
+  hostname: $YOUR_GRPC_HOSTNAME$ 
+  tlsSecret:
+    name: ambassador-grpc-cert
   requestPolicy:
     insecure:
       action: Redirect
@@ -16,7 +28,7 @@ kind: Mapping
 metadata:
   name: speakeasy-web-api
 spec:
-  hostname: $YOUR_WEB_HOSTNAME$
+  hostname: $YOUR_WEB_HOSTNAME$ 
   prefix: /v1/
   rewrite: /v1/
   service: speakeasy-service
@@ -24,19 +36,19 @@ spec:
 apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
-  name: speakeasy-web-grpc
+  name: speakeasy-web
 spec:
-  hostname: $YOUR_WEB_HOSTNAME$
-  grpc: True
-  prefix: /grpc
-  service: speakeasy-service:90
+  hostname: $YOUR_WEB_HOSTNAME$ 
+  prefix: /
+  service: speakeasy-service:81
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
-  name: speakeasy-web
+  name: speakeasy-grpc
 spec:
-  hostname: $YOUR_WEB_HOSTNAME$
+  hostname: $YOUR_GRPC_HOSTNAME$ 
+  grpc: True
   prefix: /
-  service: speakeasy-service:81
+  service: speakeasy-service:90
 


### PR DESCRIPTION
Earlier PR reduced deployment instructions to single cert  + A record(ex. `speakeasyplatform.com`). But we will need a separate domain for gRPC so SDK can configure  `https://<domain>:<port>` as the server url. Path based routing `/grpc` won't work as placing that path before or after the port is problematic for host connection and port parsing, respectively.

HTTP01 challenge we use doesn't accept wildcard certificates, so we need a separate one. Requiring 2 certs and having 1 be for gRPC is in line with our hosted version, and we can build off this state to support gRPC for `emissary`. 