### PR TITLE
bump to 1.2.0 application server version.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   registry:
-    image: gcr.io/linen-analyst-344721/speakeasy-api/registry:release-1.1.0
+    image: gcr.io/linen-analyst-344721/speakeasy-api/registry:release-1.2.0
     environment:
       - SPEAKEASY_ENVIRONMENT=docker
       - POSTGRES_DSN=postgres://postgres:postgres@postgres:5432/registry?sslmode=disable
@@ -16,7 +16,7 @@ services:
     networks:
       - speakeasy_charts_network
   web:
-    image: gcr.io/linen-analyst-344721/speakeasy-api/web:release-1.1.0
+    image: gcr.io/linen-analyst-344721/speakeasy-api/web:release-1.2.0
     networks:
       - speakeasy_charts_network
     volumes:


### PR DESCRIPTION
Introduces capability to login with auth0

See **https://app.gitbook.com/o/59QXs9iOfaWMsUtTOdQm/s/dlpZhjqjB2mtCdodtRYP/technical-reference/self-host-speakeasy#auth0-auth** for instructions.

![Screenshot 2022-09-27 at 20 15 29](https://user-images.githubusercontent.com/2904857/192620889-c0b13c9b-cda8-40e8-8d10-faa3e6995fbc.png)
<img width="707" alt="Screenshot 2022-09-27 at 20 33 45" src="https://user-images.githubusercontent.com/2904857/192620556-02a325f8-f56d-45d3-a308-dbe997af8d3f.png">
<img width="541" alt="Screenshot 2022-09-27 at 20 39 43" src="https://user-images.githubusercontent.com/2904857/192620570-67b7c608-ac11-4c84-a9b1-5c878a3e3ce1.png">
<img width="615" alt="Screenshot 2022-09-27 at 20 41 12" src="https://user-images.githubusercontent.com/2904857/192620611-08c7a89b-b819-4485-961a-379046bfc4c9.png">
<img width="1419" alt="Screenshot 2022-09-27 at 20 41 25" src="https://user-images.githubusercontent.com/2904857/192620620-23a3af53-9ee4-4f3b-8ae5-52b151af9d23.png">
