### PR TITLE
added var to deployment

### DIFF
--- a/charts/speakeasy-k8s/Chart.yaml
+++ b/charts/speakeasy-k8s/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "2.5.1"
+version: "2.5.2"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
+++ b/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
@@ -129,6 +129,11 @@ spec:
         - name: end-user-portal
           image: "gcr.io/linen-analyst-344721/speakeasy-api/end-user-portal:{{ .Values.registry.image.tag }}"
           imagePullPolicy: Always
+          env:
+            {{- range $v := .Values.portal.envVars }}
+            - name: {{ $v.key}}
+              value: {{ $v.value}}
+            {{- end }}
         {{- end }}
       volumes:
       - name: service-account-credentials

--- a/charts/speakeasy-k8s/values.yaml
+++ b/charts/speakeasy-k8s/values.yaml
@@ -87,6 +87,9 @@ portal:
   #secretAccessKeySecret:
   #  name: ""
   #  key: ""
+  envVars:
+    - key: SERVER_URL
+      value: https://api.speakeasyapi.dev
 
 bigquery:
   # GCP project containing Bigquery bounded/unbounded request tables


### PR DESCRIPTION
This lets us specify the server url for the end-user portal, which can't use the `"/"` in the same way that the other frontends do because it's SSR.