### PR TITLE
feat: capability to have custom portal domains per-workspace

### DIFF
--- a/charts/speakeasy-k8s/Chart.yaml
+++ b/charts/speakeasy-k8s/Chart.yaml
@@ -15,7 +15,7 @@ version: "3.0.0"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0-sha-350241f"
+appVersion: "1.1.0-sha-350241f"
 
 # add ingress-nginx and emissary-ingress dependencies once we can provision their controller services on a static IP
 dependencies:

--- a/charts/speakeasy-k8s/templates/ingress.yaml
+++ b/charts/speakeasy-k8s/templates/ingress.yaml
@@ -27,6 +27,9 @@ spec:
         {{- range $v := .Values.portal.portalWildcardDomains }}
         - {{ $v | quote}}
         {{- end }}
+        {{- range $v := .Values.portal.portalAdditionalHosts }}
+        - {{ $v.host | quote}}
+        {{- end }}
         {{- end }}
       secretName: nginx-letsencrypt-registry
   rules:
@@ -100,5 +103,24 @@ spec:
             path: /
             pathType: Prefix
         {{- end }}
+    {{- range $v := .Values.portal.portalAdditionalHosts }}
+    - host: {{ $v.host | quote }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: 80
+            path: /v1/
+            pathType: Prefix
+          - backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: 83
+            path: /
+            pathType: Prefix
+      {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
+++ b/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
@@ -93,6 +93,10 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
             {{- end }}
+            {{- if .Values.portal.enabled }}
+            - name: "HOST_TO_PORTAL_WORKSPACE_ID"
+              value: {{ range $k, $v := .Values.portal.portalAdditionalHosts}}{{if $k }},{{end}}{{$v.host}}={{$v.workspaceId}}{{ end }}
+            {{- end }}
             {{- range $v := .Values.registry.envVars }}
             - name: {{ $v.key}}
               value: {{ $v.value}}
@@ -144,6 +148,8 @@ spec:
             - name: {{ $v.key}}
               value: {{ $v.value}}
             {{- end }}
+            - name: "HOST_TO_PORTAL_WORKSPACE_ID"
+              value: {{ range $k, $v := .Values.portal.portalAdditionalHosts}}{{if $k }},{{end}}{{$v.host}}={{$v.workspaceId}}{{ end }}
         {{- end }}
       volumes:
       {{- if .Values.registry.svcSecretName }}

--- a/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
+++ b/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
@@ -96,6 +96,8 @@ spec:
             {{- if .Values.portal.enabled }}
             - name: "HOST_TO_PORTAL_WORKSPACE_ID"
               value: {{ range $k, $v := .Values.portal.portalAdditionalHosts}}{{if $k }},{{end}}{{$v.host}}={{$v.workspaceId}}{{ end }}
+            - name: "PORTAL_DOMAIN"
+              value: {{ first .Values.portal.portalWildcardDomains | trimPrefix "*" | quote }}
             {{- end }}
             {{- range $v := .Values.registry.envVars }}
             - name: {{ $v.key}}

--- a/charts/speakeasy-k8s/values.yaml
+++ b/charts/speakeasy-k8s/values.yaml
@@ -77,6 +77,13 @@ portal:
     - "*.portal.app.speakeasyapi.dev"
   # Provider name (cloudDNS | route53) (https://github.com/bitnami/charts/tree/main/bitnami/external-dns)
   provider: cloudDNS
+
+
+  # List of additional portal hostnames.
+  portalAdditionalHosts:
+#  - host: portal.mydomain.com
+#    portalWorkspaceId: myWorkspaceID
+
   # Required properties for cloudDNS
   #project: ""
   #serviceAccountSecretRef:


### PR DESCRIPTION
This enables the capability to configure an explicit host at an arbitrary domain to reach a specific speakeasy portal.

For example, to configure the mapping: `test_portal.speakeasyapi.dev` => `test.portal.speakeasyapi.dev` 

Would require a new values.yaml entry:

```
  portalAdditionalHosts:
    - host: "test_portal.speakeasyapi.dev"
      workspaceId: "myWorkspaceID"
```

Where `myWorkspaceID` is taken from the Speakeasy workspace entry for `test.portal.speakeasyapi.dev`.

Once this is done, the certbot dependency will attempt to do a HTTP-01 Challenge to issue a `test_portal.speakeasyapi.dev` certificate, and map it into the ingress rules. As such, a user can add a `CNAME` from `test_portal.speakeasyapi.dev` to `*.portal.speakeasyapi.dev` at any time, and the route should start resolving appropriately to the portal associated with that user's workspace.