### PR TITLE
Feat/generic env vars

### DIFF
--- a/charts/speakeasy-k8s/Chart.yaml
+++ b/charts/speakeasy-k8s/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "3.1.0"
+version: "4.0.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/speakeasy-k8s/README.md
+++ b/charts/speakeasy-k8s/README.md
@@ -101,11 +101,11 @@ registry:
   image:
     tag: 1.0.0
   envVars:
-      - key: POSTGRES_DSN
+      - name: POSTGRES_DSN
         value: postgres://postgres:postgres@34.149.47.53:5432/postgres?sslmode=disable
-      - key: BIGQUERY_PROJECT
+      - name: BIGQUERY_PROJECT
         value: your-gcloud-project
-      - key: BIGQUERY_DSN
+      - name: BIGQUERY_DSN
         value: your-dataset
   ingress:
     enabled: true

--- a/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
+++ b/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
@@ -100,8 +100,7 @@ spec:
               value: {{ first .Values.portal.portalWildcardDomains | trimPrefix "*" | quote }}
             {{- end }}
             {{- range $v := .Values.registry.envVars }}
-            - name: {{ $v.key}}
-              value: {{ $v.value}}
+            - {{ $v }}
             {{- end }}
           imagePullPolicy: Always
           livenessProbe:
@@ -147,8 +146,7 @@ spec:
           imagePullPolicy: Always
           env:
             {{- range $v := .Values.portal.envVars }}
-            - name: {{ $v.key}}
-              value: {{ $v.value}}
+            - {{ $v }}
             {{- end }}
             - name: "HOST_TO_PORTAL_WORKSPACE_ID"
               value: {{ range $k, $v := .Values.portal.portalAdditionalHosts}}{{if $k }},{{end}}{{$v.host}}={{$v.workspaceId}}{{ end }}

--- a/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
+++ b/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
@@ -100,7 +100,7 @@ spec:
               value: {{ first .Values.portal.portalWildcardDomains | trimPrefix "*" | quote }}
             {{- end }}
             {{- range $v := .Values.registry.envVars }}
-            - {{ $v }}
+            - {{ $v | toYaml | indent 14 | trim }}
             {{- end }}
           imagePullPolicy: Always
           livenessProbe:
@@ -146,7 +146,7 @@ spec:
           imagePullPolicy: Always
           env:
             {{- range $v := .Values.portal.envVars }}
-            - {{ $v }}
+            - {{ $v | toYaml | indent 14 | trim }}
             {{- end }}
             - name: "HOST_TO_PORTAL_WORKSPACE_ID"
               value: {{ range $k, $v := .Values.portal.portalAdditionalHosts}}{{if $k }},{{end}}{{$v.host}}={{$v.workspaceId}}{{ end }}

--- a/charts/speakeasy-k8s/values.yaml
+++ b/charts/speakeasy-k8s/values.yaml
@@ -14,7 +14,7 @@ fullnameOverride: ""
 registry:
   # Environment variables to expose in the Speakeasy deployment
   # envVars:
-  #   - key: EXAMPLE_ENV_VAR_KEY
+  #   - name: EXAMPLE_ENV_VAR_KEY
   #     value: EXAMPLE_ENV_VAR_VALUE
   image:
     # Please override with latest stable version
@@ -100,7 +100,7 @@ portal:
   #  name: ""
   #  key: ""
   envVars:
-    - key: SERVER_URL
+    - name: SERVER_URL
       value: https://api.speakeasyapi.dev
 
 bigquery:

--- a/charts/speakeasy-k8s/values.yaml
+++ b/charts/speakeasy-k8s/values.yaml
@@ -18,7 +18,7 @@ registry:
   #     value: EXAMPLE_ENV_VAR_VALUE
   image:
     # Please override with latest stable version
-    tag: sha-9a7caf8
+    tag: sha-df470c5
   # Secret containing the service account key file for the registry
   # svcSecretName: service-account-secret
   # key in the secret specified in svcSecretName that maps to the service account private key used for the registry

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,16 @@
 version: "3.9"
 services:
+  reverse-proxy:
+    image: nginx
+    volumes:
+      - ./scripts/nginx-docker.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - "registry"
+      - "web"
+    ports:
+      - "35291:35291"
+    networks:
+      - speakeasy_charts_network
   registry:
     image: gcr.io/linen-analyst-344721/speakeasy-api/registry:sha-df470c5
     environment:
@@ -22,7 +33,7 @@ services:
     volumes:
       - ~/.config/:/root/.config
     ports:
-      - "35291:35291"
+      - "35294:35291"
   embed-fixture:
     image: gcr.io/linen-analyst-344721/speakeasy-api/embed-fixture:sha-df470c5
     networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   registry:
-    image: gcr.io/linen-analyst-344721/speakeasy-api/registry:release-1.3.0
+    image: gcr.io/linen-analyst-344721/speakeasy-api/registry:sha-df470c5
     environment:
       - SPEAKEASY_ENVIRONMENT=docker
       - POSTGRES_DSN=postgres://postgres:postgres@postgres:5432/registry?sslmode=disable
@@ -16,7 +16,7 @@ services:
     networks:
       - speakeasy_charts_network
   web:
-    image: gcr.io/linen-analyst-344721/speakeasy-api/web:release-1.3.0
+    image: gcr.io/linen-analyst-344721/speakeasy-api/web:sha-df470c5
     networks:
       - speakeasy_charts_network
     volumes:
@@ -24,7 +24,7 @@ services:
     ports:
       - "35291:35291"
   embed-fixture:
-    image: gcr.io/linen-analyst-344721/speakeasy-api/embed-fixture:release-1.3.0
+    image: gcr.io/linen-analyst-344721/speakeasy-api/embed-fixture:sha-df470c5
     networks:
       - speakeasy_charts_network
     volumes:
@@ -32,7 +32,7 @@ services:
     ports:
       - "35292:35292"
   end-user-portal:
-    image: gcr.io/linen-analyst-344721/speakeasy-api/end-user-portal:release-1.0.0
+    image: gcr.io/linen-analyst-344721/speakeasy-api/end-user-portal:sha-df470c5
     networks:
       - speakeasy_charts_network
     volumes:

--- a/scripts/nginx-docker.conf
+++ b/scripts/nginx-docker.conf
@@ -1,0 +1,18 @@
+server {
+    listen       35291;
+    listen  [::]:35291;
+    server_name  localhost;
+
+    location / {
+        proxy_pass              http://web:35291/;
+    }
+
+    location /v1 {
+        proxy_pass              http://registry:35290/v1;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
This enables the utilisation of an externally-managed secret in `envVars`.

E.g. 

```
          kubectl create secret generic "google-client-secret" \
                  "--from-literal=googleClientSecret=mySecretValue"
```

Followed by defining the following in `values.yaml`

```
registry:
  envVars:
    - name: GOOGLE_CLIENT_ID
      value: "my-gcp-client-id"
    - name: GOOGLE_CLIENT_SECRET
      valueFrom:
        secretKeyRef:
          name: "google-client-secret"
          key: "googleClientSecret"
    - name: GOOGLE_CALLBACK_URL
      value: "https://test.speakeasyapi.dev/v1/auth/callback/google"
```

Enables google login, but without passing secrets directly.