### PR TITLE
Expose deployment/replicas field

### DIFF
--- a/charts/speakeasy-k8s/Chart.yaml
+++ b/charts/speakeasy-k8s/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "4.0.0"
+version: "4.1.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
+++ b/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- include "speakeasy-registry.datadog-labels" (dict "env" .Values.env "service" $serviceName "version" "TBD" ) | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.registry.replicas }}
+  replicas: {{.Values.registry.replicas}}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "speakeasy-registry.selectorLabels" . | nindent 6 }}

--- a/charts/speakeasy-k8s/values.yaml
+++ b/charts/speakeasy-k8s/values.yaml
@@ -55,8 +55,8 @@ registry:
   # used by managed speakeasy to send invites to the platform. No need to set this value for selfhosted speakeasy
   # sendGridKey: "**********"
 
-  # An optional field that specifies the number of desired Pods for the registry-web-deployment. It defaults to 1.
-  #  replicas: 2
+  # An optional field that specifies the number of desired Pods for the registry-web-deployment.
+  replicas: 2
 
 # Notification Emails for Infrastructure Configuration (e.g. LetsEncrypt)
 # This is the email updates to manage the LetsEncrypt certificate (90 day expiration) will be sent to

--- a/charts/speakeasy-k8s/values.yaml
+++ b/charts/speakeasy-k8s/values.yaml
@@ -55,6 +55,9 @@ registry:
   # used by managed speakeasy to send invites to the platform. No need to set this value for selfhosted speakeasy
   # sendGridKey: "**********"
 
+  # An optional field that specifies the number of desired Pods for the registry-web-deployment. It defaults to 1.
+  replicas: 1
+
 # Notification Emails for Infrastructure Configuration (e.g. LetsEncrypt)
 # This is the email updates to manage the LetsEncrypt certificate (90 day expiration) will be sent to
 # notificationEmail: "anuraag@speakeasyapi.dev"

--- a/charts/speakeasy-k8s/values.yaml
+++ b/charts/speakeasy-k8s/values.yaml
@@ -56,7 +56,7 @@ registry:
   # sendGridKey: "**********"
 
   # An optional field that specifies the number of desired Pods for the registry-web-deployment. It defaults to 1.
-  replicas: 1
+  #  replicas: 1
 
 # Notification Emails for Infrastructure Configuration (e.g. LetsEncrypt)
 # This is the email updates to manage the LetsEncrypt certificate (90 day expiration) will be sent to

--- a/charts/speakeasy-k8s/values.yaml
+++ b/charts/speakeasy-k8s/values.yaml
@@ -56,7 +56,7 @@ registry:
   # sendGridKey: "**********"
 
   # An optional field that specifies the number of desired Pods for the registry-web-deployment. It defaults to 1.
-  #  replicas: 1
+  #  replicas: 2
 
 # Notification Emails for Infrastructure Configuration (e.g. LetsEncrypt)
 # This is the email updates to manage the LetsEncrypt certificate (90 day expiration) will be sent to


### PR DESCRIPTION
Expose an optional field that specifies the number of desired Pods for the registry-web-deployment. It defaults to 1.