### PR TITLE
Fix: Add container grace period

### DIFF
--- a/charts/speakeasy-k8s/Chart.yaml
+++ b/charts/speakeasy-k8s/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "4.1.0"
+version: "4.1.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -35,4 +35,3 @@ dependencies:
     version: 4.0.13
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
-

--- a/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
+++ b/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
@@ -110,7 +110,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 15
             successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 1
             httpGet:
               path: /
               port: 35290

--- a/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
+++ b/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
@@ -107,10 +107,18 @@ spec:
             {{- end }}
           imagePullPolicy: Always
           livenessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            successThreshold: 1
+            failureThreshold: 3
             httpGet:
               path: /
               port: 35290
           readinessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            successThreshold: 1
+            failureThreshold: 3
             httpGet:
               path: /
               port: 35290


### PR DESCRIPTION
Adds a grace period to container boot.

Values are set via the following reasoning:

            # We observe a ~ 2 second boot time in the current version. This doubles that
            initialDelaySeconds: 5
            # Our Periodic healthcheck returns cached results for up to 15 seconds.
            periodSeconds: 15
            # Health checks stateless; 1 success implies future success
            successThreshold: 1
            # Transient failures in a container imply it should immediately halt getting new traffic, until next successful health check.
            readinessProbe.failureThreshold: 1
            # Failed healthchecks which repeat themselves 3 times should get restarted. E.g. a transient DB connection failure vs a longer-term permanent connection
            livenessProbe.failureThreshold: 3