### PR TITLE
fix: keep cloud-sql-proxy alive whilst application terminating

### DIFF
--- a/charts/speakeasy-k8s/Chart.yaml
+++ b/charts/speakeasy-k8s/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "4.1.1"
+version: "4.1.2"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
+++ b/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
@@ -139,6 +139,7 @@ spec:
             - "/cloud_sql_proxy"
             - "-log_debug_stdout"
             - "{{ .Values.registry.cloudsql.connectionString }}"
+            - "-term_timeout=30s"
             - "-credential_file=/secrets/{{ .Values.registry.svcSecretKey }}"
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
This adds the `term_timeout` parameter to cloud-sql-proxy. 

By default, the cloud-sql-proxy automatically terminates when receiving a TERM signal, despite having any open connections. This implies during a roll-over deployment, if there are any existing requests being processed, the DB connection being closed will cancel these requests.

Speakeasy-Registry has a deployment strategy that allows a time window of ~30 seconds between new connections being stopped to an application instance, and the application instance being terminated. This is intended to allow for graceful upgrade of application instances without downtime. However, without this change, should the cluster be configured with cloud-sql-proxy, that container shutting down will be a blocker to the intended graceful nature of the deployment; instead immediately causing these ongoing requests to be immediately rolled back and responses returned to invoking clients.

This change should bring us closer (if not completely there) to a zero-downtime deployment, assuming all requests are handled within 30 seconds.