### PR TITLE
Feat: pass through an optional redis address

### DIFF
--- a/charts/speakeasy-k8s/Chart.yaml
+++ b/charts/speakeasy-k8s/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "4.1.2"
+version: "4.2.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
+++ b/charts/speakeasy-k8s/templates/registry-web-deployment.yaml
@@ -36,6 +36,14 @@ spec:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/secrets/{{ .Values.registry.svcSecretKey }}"
             {{- end }}
+            {{- if .Values.registry.cache.redisAddr }}
+            - name: REDIS_ADDR
+              value: {{ .Values.registry.cache.redisAddr }}
+            {{- end }}
+            {{- if .Values.registry.cache.redisPassword }}
+            - name: REDIS_PASSWORD
+              value: {{ .Values.registry.cache.redisPassword }}
+            {{- end }}
             - name: POSTGRES_DSN
               value: {{ .Values.postgresql.DSN }}
             - name: POSTHOG_API_KEY

--- a/charts/speakeasy-k8s/values.yaml
+++ b/charts/speakeasy-k8s/values.yaml
@@ -24,6 +24,15 @@ registry:
   # key in the secret specified in svcSecretName that maps to the service account private key used for the registry
   # svcSecretKey: service_account.json
 
+  # Expose an optional cache (via redis API) to increase registry performance.
+  # Cache not expected to be persistent. All cache keys will be set with a suffix of the registry version
+  # Tested with GCP google_redis_instance in HIGH_AVAILABILITY mode maxmemory=1GB maxmemory-policy = "allkeys-lru"
+  cache:
+    # host:port address
+    redisAddr:
+    # optional password
+    redisPassword:
+
   ingress:
     # If true, *Hostnames values below must also be set.
     # Deploys an ingress for the registry API if both the above criteria are met


### PR DESCRIPTION
Enables the optional configuration of the `REDIS_ADDR` and `REDIS_PASSWORD` environment variables to a helm `values.yaml` instance, without overriding envVars.

When configured, the registry will act in a more performant manner -- with DB read/write intensive SQL interactions being cached by redis. 