### PR TITLE
refactor: cleanup posthog env vars

### DIFF
--- a/charts/speakeasy-k8s/Chart.yaml
+++ b/charts/speakeasy-k8s/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "4.5.3"
+version: "4.5.4"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/speakeasy-k8s/templates/_helpers.tpl
+++ b/charts/speakeasy-k8s/templates/_helpers.tpl
@@ -98,10 +98,6 @@ Registry Env Vars
 {{- end }}
 - name: POSTGRES_DSN
   value: {{ .Values.postgresql.DSN }}
-- name: POSTHOG_API_KEY
-  value: phc_hiYSF5Axu49I1xs4Z5BG8KCI3PGNLM8ERRs7eocmfX9
-- name: POSTHOG_ENDPOINT
-  value: {{ if eq .Values.env "prod" }}https://metrics.speakeasyapi.dev{{ else }}{{ printf "https://metrics.%s.speakeasyapi.dev" .Values.env }}{{ end }}
 - name: SPEAKEASY_ENVIRONMENT
   value: {{ .Values.env }}
 {{- if .Values.auth.SignInURL }}

--- a/charts/speakeasy-k8s/values.yaml
+++ b/charts/speakeasy-k8s/values.yaml
@@ -14,10 +14,10 @@ fullnameOverride: ""
 registry:
   # Environment variables to expose in the Speakeasy deployment
   envVars:
-  - name: POSTHOG_API_KEY
-    value: phc_hiYSF5Axu49I1xs4Z5BG8KCI3PGNLM8ERRs7eocmfX9
-  - name: POSTHOG_ENDPOINT
-    value: metrics.speakeasyapi.dev
+    - name: POSTHOG_API_KEY
+      value: phc_hiYSF5Axu49I1xs4Z5BG8KCI3PGNLM8ERRs7eocmfX9
+    - name: POSTHOG_ENDPOINT
+      value: metrics.speakeasyapi.dev
   image:
     # Please override with latest stable version
     tag: sha-df470c5

--- a/charts/speakeasy-k8s/values.yaml
+++ b/charts/speakeasy-k8s/values.yaml
@@ -13,9 +13,11 @@ fullnameOverride: ""
 # Registry service hosting the Speakeasy API
 registry:
   # Environment variables to expose in the Speakeasy deployment
-  # envVars:
-  #   - name: EXAMPLE_ENV_VAR_KEY
-  #     value: EXAMPLE_ENV_VAR_VALUE
+  envVars:
+  - name: POSTHOG_API_KEY
+    value: phc_hiYSF5Axu49I1xs4Z5BG8KCI3PGNLM8ERRs7eocmfX9
+  - name: POSTHOG_ENDPOINT
+    value: metrics.speakeasyapi.dev
   image:
     # Please override with latest stable version
     tag: sha-df470c5

--- a/charts/speakeasy-k8s/values.yaml
+++ b/charts/speakeasy-k8s/values.yaml
@@ -13,11 +13,9 @@ fullnameOverride: ""
 # Registry service hosting the Speakeasy API
 registry:
   # Environment variables to expose in the Speakeasy deployment
-  envVars:
-    - name: POSTHOG_API_KEY
-      value: phc_hiYSF5Axu49I1xs4Z5BG8KCI3PGNLM8ERRs7eocmfX9
-    - name: POSTHOG_ENDPOINT
-      value: metrics.speakeasyapi.dev
+  # envVars:
+  #   - name: EXAMPLE_ENV_VAR_KEY
+  #     value: EXAMPLE_ENV_VAR_VALUE
   image:
     # Please override with latest stable version
     tag: sha-df470c5


### PR DESCRIPTION
posthog migration is now done (reverse proxy is in prod) so cleaning up the env vars here as requested. Don't think we actually need to modify registry's `values-x.yaml` files, because the posthog endpoint comes from the `config/` directory there anyway. These env vars were simply overriding when I don't think they were necessary, but I'll verify