### PR TITLE
fix: capability to remove Certificate / ClusterIssuer to help change cert-manager installation configuration

### DIFF
--- a/charts/speakeasy-k8s/templates/cert-manager.yaml
+++ b/charts/speakeasy-k8s/templates/cert-manager.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.portal.enabled }}
 {{- if or (index .Values "cert-manager" "enabled") .Values.createClusterIssuer -}}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -46,7 +47,6 @@ spec:
   {{- end }}
 {{- end }}
 ---
-{{- if .Values.portal.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/charts/speakeasy-k8s/templates/cert-manager.yaml
+++ b/charts/speakeasy-k8s/templates/cert-manager.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.portal.enabled }}
-{{- if or (index .Values "cert-manager" "enabled") .Values.createClusterIssuer -}}
+{{- if or (index .Values "cert-manager" "enabled") .Values.createCertManagerResources -}}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -45,8 +44,8 @@ spec:
           - {{ $v | quote }}
         {{- end }}
   {{- end }}
-{{- end }}
 ---
+{{- if .Values.portal.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -61,4 +60,5 @@ spec:
   {{- range $v :=  .Values.portal.portalWildcardDomains }}
   - {{ $v | quote }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/speakeasy-k8s/values.yaml
+++ b/charts/speakeasy-k8s/values.yaml
@@ -71,7 +71,7 @@ registry:
 # This is the email updates to manage the LetsEncrypt certificate (90 day expiration) will be sent to
 # notificationEmail: "anuraag@speakeasyapi.dev"
 # when cert-manager is enabled a cluster issuer will be created. If you want to create the cluster issuer even if cert-manager is disabled (i.e. you installed cert-manager some other way) then set this to true
-# createClusterIssuer : true
+createCertManagerResources: true
 cert-manager:
   enabled: false
   installCRDs: true
@@ -81,7 +81,6 @@ cert-manager:
       - 8.8.8.8
       - 1.1.1.1
       - 208.67.222.222
-
 portal:
   enabled: true
   # The wildcard domain that will route to the self-serve portal

--- a/terraform/k8s/helm.tf
+++ b/terraform/k8s/helm.tf
@@ -143,7 +143,7 @@ resource "helm_release" "speakeasy" {
   }
 
   set {
-    name  = "createClusterIssuer"
+    name  = "createCertManagerResources"
     value = var.ingressNginxEnabled ? "true" : "false"
   }
 


### PR DESCRIPTION
 * This enables changing certificate-manager CRDs to an externally deployed (and referenced) model